### PR TITLE
ZON-4784: Use editorial as default sort

### DIFF
--- a/server/liveblog/themes/themes_assets/default/templates/template-timeline.html
+++ b/server/liveblog/themes/themes_assets/default/templates/template-timeline.html
@@ -39,7 +39,7 @@
     <div class="header-bar__interaction">
       <div class="header-bar__align-wrapper"> <!-- align menu items w/ post's content -->
         <span class="sorting-bar__order
-          {%- if settings.postOrder == 'newest_first' %} sorting-bar__order--active{% endif %}" data-js-orderby_descending>
+          {%- if settings.postOrder == 'newest_first' or settings.postOrder == 'editorial' %} sorting-bar__order--active{% endif %}" data-js-orderby_editorial>
           {{  translate("Newest first") }}
         </span>
         <span class="sorting-bar__order

--- a/server/liveblog/themes/themes_assets/default/test/options.json
+++ b/server/liveblog/themes/themes_assets/default/test/options.json
@@ -22,7 +22,7 @@
       "canComment":false,
       "language":"en",
       "postsPerPage":20,
-      "postOrder":"newest_first",
+      "postOrder":"editorial",
       "showAuthorAvatar":true,
       "showTitle":true,
       "authorNameFormat":"display_name",

--- a/server/liveblog/themes/themes_assets/default/theme.json
+++ b/server/liveblog/themes/themes_assets/default/theme.json
@@ -394,7 +394,7 @@
                 {"value": "newest_first", "label": "Newest first"},
                 {"value": "oldest_first", "label": "Oldest first"}
             ],
-            "default": "newest_first"
+            "default": "editorial"
         },
         {
             "name": "autoApplyUpdates",


### PR DESCRIPTION
Ticket: https://zeit-online.atlassian.net/browse/ZON-4784

Liveblogs sollen nun statt `Neueste zuerst` die Sortierung `editorial` verwenden. Näheres dazu im Ticket. :) 