### PR TITLE
BUG-987: Add image-gallery in amp

### DIFF
--- a/server/liveblog/themes/themes_assets/amp/less/timeline.less
+++ b/server/liveblog/themes/themes_assets/amp/less/timeline.less
@@ -10,7 +10,7 @@
   max-width: 660px;
   padding: 20px 20px 28px 40px;
   position: relative;
-  
+
   &::before {
     background-color: #ccc;
     content: '';
@@ -46,7 +46,7 @@
   .lb-post {
     margin-top: 20px;
     padding: 60px 30px 40px;
-    
+
     &::before {
       left: 10px;
       top: 80px;
@@ -244,31 +244,60 @@
 
 // Update button
 
-.lb-update-button { 
+.lb-update-button {
   background-color: #fff;
-  border-radius: 5px; 
-  border: 2px solid #ccc; 
-  color: #313131; 
-  display: block; 
+  border-radius: 5px;
+  border: 2px solid #ccc;
+  color: #313131;
+  display: block;
   font-family: inherit;
-  font-size: 13px; 
-  font-weight: bold; 
-  letter-spacing: .05em; 
-  margin: 20px auto; 
-  padding: 10px 18px; 
-  text-align: center; 
-  text-transform: uppercase; 
-  transition: all .15s ease-in-out; 
+  font-size: 13px;
+  font-weight: bold;
+  letter-spacing: .05em;
+  margin: 20px auto;
+  padding: 10px 18px;
+  text-align: center;
+  text-transform: uppercase;
+  transition: all .15s ease-in-out;
 
   &:hover,
   &:focus {
-    border-color: #999; 
+    border-color: #999;
     color: #000;
   }
 }
 
 .lb-timeline-body {
   border-top: 10px solid @yellow;
+}
+
+// Carousel
+
+.amp-carousel-slide {
+  height: initial!important;
+
+  amp-img {
+    max-height: 320px;
+    object-fit: contain;
+  }
+
+  figcaption {
+    max-height: 100px;
+    overflow-x: auto;
+  }
+
+  .item--embed__description {
+    display: block;
+    float: left;
+    font-size: 1.1em !important;
+    margin-top: 0 !important;
+    width: 80%;
+  }
+
+  .i-amphtml-fill-content {
+    min-width: auto !important;
+    width: auto !important;
+  }
 }
 
 // Timeline
@@ -330,7 +359,7 @@
   }
   .item--embed__description,
   .item--embed__credit {
-    font-size: .75em;   
+    font-size: .75em;
     margin-top: 8px;
   }
   .item--embed__credit {

--- a/server/liveblog/themes/themes_assets/amp/templates/template-item-gallery.html
+++ b/server/liveblog/themes/themes_assets/amp/templates/template-item-gallery.html
@@ -1,8 +1,7 @@
 <div class="lb-item">
   <amp-carousel class="carousel1"
-  layout="responsive"
-  height="450"
-  width="500"
+  layout="fixed-height"
+  height="420"
   type="slides">
     {% for ref in item.groups[1].refs %}
       <div>
@@ -10,13 +9,14 @@
         layout="responsive"
         width="{{ ref.item.meta.media.renditions.viewImage.width }}"
         height="{{ ref.item.meta.media.renditions.viewImage.height }}"
+        on="tap:lb-lightbox"
         alt="">
         </amp-img>
-        <figcaption class="item--embed__description">
-          {{ ref.item.meta.caption }}
-          {% if ref.item.meta.credit %}
-            <span class="credit">Credit: {{ ref.item.meta.credit }}</span>
-          {% endif %}
+        <figcaption>
+            <span class="item--embed__description">{{ ref.item.meta.caption }}</span>
+        {% if ref.item.meta.credit %}
+            <span class="credit">Credit: {{ ref.item.meta.credit }} </span>
+        {% endif %}
         </figcaption>
       </div>
     {% endfor %}


### PR DESCRIPTION
Ticket: https://zeit-online.atlassian.net/browse/BUG-987
Test: http://localhost:8008/ (`{% set gallery = true %}` themes_assets/amp/templates/template-post.html in Zeile 88)

Vorher: 
![bildschirmfoto 2018-09-10 um 15 43 43](https://user-images.githubusercontent.com/24528215/45301042-554cc980-b510-11e8-9b98-ad167c686856.png)
Nachher:
![bildschirmfoto 2018-09-10 um 15 43 49](https://user-images.githubusercontent.com/24528215/45301048-5a117d80-b510-11e8-8592-92d0f32ecd77.png)
