### PR TITLE
BUG-1226: Sharing buttons

### DIFF
--- a/server/liveblog/themes/themes_assets/default/templates/template-post.html
+++ b/server/liveblog/themes/themes_assets/default/templates/template-post.html
@@ -167,12 +167,12 @@
       <li class="lb-sharing__item lb-sharing__item--facebook">
         <a class="lb-post-shareBox__item"
           onclick="window.open(this.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=570,height=400');return false;"
-          data-link-base="//www.facebook.com/sharer.php?s=100&p[title]=&p[url]=" data-link-id={{item._id}}></a>
+          data-link-base="//www.facebook.com/sharer.php?s=100&p[title]=&u=" data-link-id={{item._id}}></a>
       </li>
       <li class="lb-sharing__item lb-sharing__item--twitter">
         <a class="lb-post-shareBox__item"
           onclick="window.open(this.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=570,height=400');return false;"
-          data-link-base="//twitter.com/home?status=" data-link-id={{item._id}}></a>
+          data-link-base="//twitter.com/share?url=" data-link-id={{item._id}}></a>
       </li>
       <li class="lb-sharing__item lb-sharing__item--email">
         <a class="lb-post-shareBox__item"


### PR DESCRIPTION
### Was erledigt dieser PR?
Fixed die sharing-buttons für Facebook und Twitter.

Gesehen u.a. hier: 
https://www.zeit.de/wissen/gesundheit/2020-03/covid-19-coronavirus-infektionen-ausbreitung-live-blog

### Wie kann getestet werden?
Testen auf: http://localhost:8008/ und ordentlich teilen.

### Relevante Tickets
https://zeit-online.atlassian.net/browse/BUG-1226

### Gif
![](https://media.giphy.com/media/4vlvqMjkQ0ddC/giphy.gif)